### PR TITLE
Misalignment of "Featured Courses" Each Course Headings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1225,6 +1225,12 @@ Website- https://www.freecodecamp.org/learn/quality-assurance/<br>
 </details>
 
 <details>
+ <summary>FastAPI</summary>
+ <br>
+ Website- https://www.edx.org/learn/fastapi
+</details>
+
+<details>
 <summary>Computer Networking</summary>
 <br>Networking Essentials By Cisco Networking Academy<br>
 Website- https://www.netacad.com/courses/networking/networking-essentials<br>

--- a/src/components/data/allcourses.json
+++ b/src/components/data/allcourses.json
@@ -1770,6 +1770,15 @@
         }
     ]
 },
+{
+  "title": "FastAPI",
+  "cards": [{
+    "icon": "fa-solid fa-code",
+    "name": "FastAPI course",
+    "source": "edx",
+    "link": "https://www.edx.org/learn/fastapi"
+  }]
+},
 
 {
   "title": "Computer Networking",


### PR DESCRIPTION
This pull request contains the updated code for the misalignment of "Featured Courses" section headings. The issue related to this PR is as follows:
Misalignment of "Featured Courses" Each Course Headings #479

## Output Sample


![img (4)](https://github.com/iamRabia-N/Free-courses-with-Certificates/assets/115794049/29c9daef-819c-4dac-80fc-5eda471a7e8d)
